### PR TITLE
feat: NO-ISSUE More indentation rules

### DIFF
--- a/nix-ts-mode.el
+++ b/nix-ts-mode.el
@@ -172,6 +172,7 @@
      ((node-is "]") parent-bol 0)
      ((node-is ")") parent-bol 0)
      ((node-is "}") parent-bol 0)
+     ((node-is "''") parent-bol 0)
      ((node-is "binding_set") parent-bol nix-ts-mode-indent-offset)
      ((node-is "indented_string_expression") parent-bol nix-ts-mode-indent-offset)
      ((parent-is "formals") parent-bol 0)
@@ -179,7 +180,8 @@
      ((parent-is "binding") parent-bol nix-ts-mode-indent-offset)
      ((parent-is "list_expression") parent-bol nix-ts-mode-indent-offset)
      ((parent-is "apply_expression") parent-bol nix-ts-mode-indent-offset)
-     ((parent-is "parenthesized_expression") parent-bol nix-ts-mode-indent-offset)))
+     ((parent-is "parenthesized_expression") parent-bol nix-ts-mode-indent-offset)
+     (no-node parent-bol nix-ts-mode-indent-offset))) ; Automatically indent as soon as a new (empty) line is created
   "Tree-sitter indent rules for `nix-ts-mode'.")
 
 ;; Keymap


### PR DESCRIPTION
- automatically indent as soon as new lines are created
- partially fix indentation in multi lines strings

[Here a brief cast](https://asciinema.org/a/Tbb6oDw3uutGTDMPFUz1JJpNo).
As you can see until you close the multi lines string (some ERROR nodes appear in the tree) it doesn't work really well.

It's the first time I touch tree sitter and I'm also quite a noob with emacs, I hope what I did makes sense but I've to admit that I tried several permutations randomly before it started working (more or less).